### PR TITLE
refactor(core): :recycle: registry names camelCase to PascalCase

### DIFF
--- a/service/controllers.registry.ts
+++ b/service/controllers.registry.ts
@@ -1,10 +1,11 @@
 import * as testController from "./controllers/test.controller";
 
-const controllersRegistry = {
+const ControllersRegistry = {
   testGetAllFunc: [testController.testGetAllFunc],
   testGetFunc: [testController.testGetFunc],
   testPostFunc: [testController.testPostFunc],
   testPutFunc: [testController.testPutFunc],
   testPatchFunc: [testController.testPatchFunc],
 };
-export default controllersRegistry;
+
+export default ControllersRegistry;

--- a/service/functions.registry.ts
+++ b/service/functions.registry.ts
@@ -1,10 +1,11 @@
 import * as testFunctions from "./functions/test.functions";
 
-const functionsRegistry = {
+const FunctionsRegistry = {
   readTestData: testFunctions.readTestData,
   readTestDataAll: testFunctions.readTestDataAll,
   createTestData: testFunctions.createTestData,
   updateTestData: testFunctions.updateTestData,
   deleteTestData: testFunctions.deleteTestData,
 };
-export default functionsRegistry;
+
+export default FunctionsRegistry;

--- a/service/middlewares.registry.ts
+++ b/service/middlewares.registry.ts
@@ -1,6 +1,7 @@
 import { testMiddleware } from "./middlewares/test.middleware";
 
-const middlewaresRegistry = {
+const MiddlewaresRegistry = {
   testMiddleware: testMiddleware,
 };
-export default middlewaresRegistry;
+
+export default MiddlewaresRegistry;

--- a/service/models.registry.ts
+++ b/service/models.registry.ts
@@ -1,9 +1,10 @@
 import { TestDatas } from "./models/TestDatas.model";
 
-const modelsRegistry = {
+const ModelsRegistry = {
   TestDatas: {
     database: "application",
     model: TestDatas,
   },
 };
-export default modelsRegistry;
+
+export default ModelsRegistry;

--- a/service/routes.registry.ts
+++ b/service/routes.registry.ts
@@ -1,4 +1,4 @@
-const routesRegistry = {
+const RoutesRegistry = {
   testGetAllAPI: {
     name: "Test Get All API",
     url: "wrappidall",
@@ -40,4 +40,5 @@ const routesRegistry = {
     controllerRef: "testPatchFunc",
   },
 };
-export default routesRegistry;
+
+export default RoutesRegistry;

--- a/service/tasks.registry.ts
+++ b/service/tasks.registry.ts
@@ -1,6 +1,7 @@
 import { TestTask } from "./tasks/TestTask";
 
-const tasksRegistry = {
+const TasksRegistry = {
   TestTask: TestTask,
 };
-export default tasksRegistry;
+
+export default TasksRegistry;

--- a/service/validations.registry.ts
+++ b/service/validations.registry.ts
@@ -1,7 +1,8 @@
 import * as testValidations from "./validations/test.validation";
 
-const validationsRegistry = {
+const ValidationsRegistry = {
   getTestAll: testValidations.getTestAll,
   getTest: testValidations.getTest,
 };
-export default validationsRegistry;
+
+export default ValidationsRegistry;


### PR DESCRIPTION
## Description

All the registry name should be from camelCase to PascalCase in the service/registry files

## Related Issues

Ref #65

## Testing

N/A

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)

N/A

## Additional Notes

N/A

## Reviewers

N/A

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
